### PR TITLE
Move untildify to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "cz-conventional-changelog": "^1.1.5",
     "ghooks": "^1.2.0",
     "semantic-release": "^4.3.5",
-    "untildify": "^2.1.0",
     "validate-commit-msg": "^2.5.0",
     "xo": "^0.14.0"
   },
@@ -45,6 +44,7 @@
   },
   "dependencies": {
     "tildify": "^1.2.0",
+    "untildify": "^2.1.0",
     "username": "^2.1.0",
     "watch-and-exec": "^1.0.0",
     "yargs": "^4.6.0"


### PR DESCRIPTION
This fixes a crash:

```
watch-and-rsync -o=start -s=~/p/a -t=~/p/b
module.js:442
    throw err;
    ^

Error: Cannot find module 'untildify'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.Module._load (module.js:388:25)
    at Module.require (module.js:468:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/usr/local/lib/node_modules/watch-and-rsync/src/index.js:10:19)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
```

Thanks for a great tool!